### PR TITLE
WIP: Support private browser

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -205,7 +205,6 @@ async function init() {
 function handleMessage(request, sender, sendResponse) {
 	if (request === "init") {
 		init();
-	} else if(request === "config") {
 		sendResponse(config);
 	}
 }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -202,4 +202,14 @@ async function init() {
 	browser.tabs.onActivated.addListener(tabActivated);
 }
 
+function handleMessage(request, sender, sendResponse) {
+	if (request === "init") {
+		init();
+	} else if(request === "config") {
+		sendResponse(config);
+	}
+}
+
+browser.runtime.onMessage.addListener(handleMessage);
+
 init();

--- a/src/js/groupNodes.js
+++ b/src/js/groupNodes.js
@@ -211,7 +211,7 @@ async function fillGroupNodes() {
 
 	groups.forEach(function(group) {
 		groupNodes[group.id].content.insertBefore(fragment[group.id], groupNodes[group.id].newtab);
-		updateGroupFit(group);
+		updateGroupFit(group).then();
 	});
 }
 
@@ -246,7 +246,7 @@ async function insertTab(tab) {
 	}
 }
 
-function updateGroupFit(group) {
+async function updateGroupFit(group) {
 
 	var node = groupNodes[group.id];
 	var childNodes = node.content.childNodes;
@@ -256,16 +256,16 @@ function updateGroupFit(group) {
 
 	// fit
 	var rect = node.content.getBoundingClientRect();
-
-	var ratio = background.config.tab.ratio;
+	var config = await browser.runtime.sendMessage("config");
+	var ratio = config.tab.ratio;
 	var small = false;
 
 	var fit = getBestFit({
 		width: rect.width,
 		height: rect.height,
 
-		minWidth: background.config.tab.minWidth,
-		maxWidth: background.config.tab.maxWidth,
+		minWidth: config.tab.minWidth,
+		maxWidth: config.tab.maxWidth,
 
 		ratio: ratio,
 

--- a/src/js/groupNodes.js
+++ b/src/js/groupNodes.js
@@ -211,7 +211,7 @@ async function fillGroupNodes() {
 
 	groups.forEach(function(group) {
 		groupNodes[group.id].content.insertBefore(fragment[group.id], groupNodes[group.id].newtab);
-		updateGroupFit(group).then();
+		updateGroupFit(group);
 	});
 }
 
@@ -246,8 +246,7 @@ async function insertTab(tab) {
 	}
 }
 
-async function updateGroupFit(group) {
-
+function updateGroupFit(group) {
 	var node = groupNodes[group.id];
 	var childNodes = node.content.childNodes;
 
@@ -256,16 +255,15 @@ async function updateGroupFit(group) {
 
 	// fit
 	var rect = node.content.getBoundingClientRect();
-	var config = await browser.runtime.sendMessage("config");
-	var ratio = config.tab.ratio;
+	var ratio = view.config.tab.ratio;
 	var small = false;
 
 	var fit = getBestFit({
 		width: rect.width,
 		height: rect.height,
 
-		minWidth: config.tab.minWidth,
-		maxWidth: config.tab.maxWidth,
+		minWidth: view.config.tab.minWidth,
+		maxWidth: view.config.tab.maxWidth,
 
 		ratio: ratio,
 
@@ -297,8 +295,6 @@ async function updateGroupFit(group) {
 		}
 	}
 
-	var index = 0;
-
 	var w = rect.width  / fit.x;
 	var h = w * ratio;
 
@@ -311,10 +307,8 @@ async function updateGroupFit(group) {
 
 		childNodes[i].style.width = w + 'px';
 		childNodes[i].style.height = h + 'px';
-		childNodes[i].style.left = (w * (index % fit.x)) + 'px';
-		childNodes[i].style.top = (h * Math.floor(index / fit.x)) + 'px';
-
-		index++;
+		childNodes[i].style.left = (w * (i % fit.x)) + 'px';
+		childNodes[i].style.top = (h * Math.floor(i / fit.x)) + 'px';
 	}
 
 }

--- a/src/js/view.js
+++ b/src/js/view.js
@@ -23,7 +23,7 @@ function new_element(name, attributes, children) {
 	return e;
 }
 
-var background = browser.extension.getBackgroundPage();
+browser.runtime.sendMessage("init");
 
 var view = {
 	windowId: -1,
@@ -123,7 +123,7 @@ async function createGroup() {
 	makeGroupNode(group);
 	var groupElement = groupNodes[group.id].group
 	view.groupsNode.appendChild(groupElement);
-	updateGroupFit(group);
+	await updateGroupFit(group);
 	groupElement.scrollIntoView({behavior: "smooth"});
 }
 
@@ -141,7 +141,7 @@ async function tabCreated(tab) {
 
 		var group = groups.get(groupId);
 		await insertTab(tab);
-		updateGroupFit(group);
+		await updateGroupFit(group);
 	}
 }
 
@@ -149,7 +149,7 @@ function tabRemoved(tabId, removeInfo) {
 	if(view.windowId == removeInfo.windowId && view.tabId != tabId){
 		deleteTabNode(tabId);
 		groups.forEach(function(group) {
-			updateGroupFit(group);
+			updateGroupFit(group).then();
 		});
 	}
 }
@@ -165,8 +165,8 @@ async function tabMoved(tabId, moveInfo) {
 	if(view.windowId == moveInfo.windowId){
 		browser.tabs.get(tabId).then(async function(tab) {
 			await insertTab(tab);
-			groups.forEach(async function(group) {
-				updateGroupFit(group);
+			groups.forEach(function(group) {
+				updateGroupFit(group).then();
 			});
 		});
 	}
@@ -186,7 +186,7 @@ function tabDetached(tabId, detachInfo) {
 	if(view.windowId == detachInfo.oldWindowId){
 		deleteTabNode(tabId);
 		groups.forEach(function(group) {
-			updateGroupFit(group);
+			updateGroupFit(group).then();
 		});
 	}
 }


### PR DESCRIPTION
This PR should fix #26. 

I completly replaced the usage of `browser.extension.getBackgroundPage()` with `browser.runtime.sendMessage()` to enable support in private browsers. While I was at it I cleaned up and fixed some async/await code.

Some things to note: 

1. I have set this PR as WIP since I wanted to have your opinion first in how this whole runtime.sendMessage() should be implemented. After all this will decide how content-script and background-script will communicate with each other in the future. I only made a (sloppy) implementation as groundwork to show you how it can be done. 
2. While reading the code I discovered some nasty code smells. In groups.js you implemented a downgraded version of `forEach()`. When I first saw this I thought it is the default forEach you would know from JavaScript, but was later surprised when my code didn't work as intended until I investigated it. In tabs.js you did the same thing, but worse, since you made it an async call. This makes this pretty inconsistent... especially since I first "fixed" it because I thought it's the default forEach, which doesn't support async callbacks.