### PR TITLE
Remove the config variable from background.js

### DIFF
--- a/src/js/groupNodes.js
+++ b/src/js/groupNodes.js
@@ -257,15 +257,15 @@ function updateGroupFit(group) {
 	// fit
 	var rect = node.content.getBoundingClientRect();
 
-	var ratio = background.config.tab.ratio;
+	var ratio = 0.68;
 	var small = false;
 
 	var fit = getBestFit({
 		width: rect.width,
 		height: rect.height,
 
-		minWidth: background.config.tab.minWidth,
-		maxWidth: background.config.tab.maxWidth,
+		minWidth: 100,
+		maxWidth: 250,
 
 		ratio: ratio,
 

--- a/src/js/view.js
+++ b/src/js/view.js
@@ -23,8 +23,6 @@ function new_element(name, attributes, children) {
 	return e;
 }
 
-var background = browser.extension.getBackgroundPage();
-
 var view = {
 	windowId: -1,
 	tabId: -1,


### PR DESCRIPTION
These numbers are not actually configurable, and if they were the proper
place to store them would be browser.storage, not in background.js.

Fixes #26, because with view.html no longer needing information from
background.js, we can remove the call to getBackgroundPage().

This is an alternative to #33 