### PR TITLE
Add triggerCommand to runtime message listener

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -252,6 +252,7 @@ async function init() {
 	await migrate(); //keep until everyone are on 0.8.0
 
 	browser.commands.onCommand.addListener(triggerCommand);
+	browser.runtime.onMessage.addListener(triggerCommand);
 	browser.browserAction.onClicked.addListener(toggleView);
 	browser.windows.onCreated.addListener(createGroupInWindow);
 	browser.tabs.onCreated.addListener(tabCreated);

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -252,7 +252,7 @@ async function init() {
 	await migrate(); //keep until everyone are on 0.8.0
 
 	browser.commands.onCommand.addListener(triggerCommand);
-	browser.runtime.onMessage.addListener(triggerCommand);
+	browser.runtime.onMessageExternal.addListener(triggerCommand);
 	browser.browserAction.onClicked.addListener(toggleView);
 	browser.windows.onCreated.addListener(createGroupInWindow);
 	browser.tabs.onCreated.addListener(tabCreated);


### PR DESCRIPTION
To enable other extensions to access panorama, the `runtime` should also be listened on for commands.