### PR TITLE
Respect the "pinned" state of the tabs

### DIFF
--- a/src/js/backup.js
+++ b/src/js/backup.js
@@ -74,6 +74,7 @@ async function openBackup(data) {
 				url: data.windows[wi].tabs[ti].url,
 				active: false,
 				windowId: window.id,
+				pinned: data.windows[wi].tabs[ti].pinned || false,
 			}).catch((err) => { console.log(err); });
 
 			if(tab) {
@@ -177,14 +178,19 @@ async function saveBackup() {
 			var groupId = await browser.sessions.getTabValue(tab.id, 'groupId');
 
 			if(groupId != -1) {
-				data.windows[wi].tabs.push({
+				var entry = {
 					url: tab.url,
 					title: tab.title,
 					groupId: groupId,
 					index: tab.index,
 					lastAccessed: tab.lastAccessed,
-					pinned: tab.pinned,
-				});
+				}
+
+				if (tab.pinned === true) {
+					entry.pinned = tab.pinned
+				}
+
+				data.windows[wi].tabs.push(entry);
 			}
 		}
 	}


### PR DESCRIPTION
Store in the backups and restore the `pinned` state of tabs. Fixes #67.