### PR TITLE
Add command listener to external message listener

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -61,6 +61,7 @@ async function init() {
 	await addon.initialize();
 
 	browser.commands.onCommand.addListener(handleCommands);
+	browser.runtime.onMessageExternal.addListener(handleCommands);
 
 	await setupWindows();
 	await salvageGrouplessTabs();


### PR DESCRIPTION
This allows other extensions to trigger the same commands that are available as keyboard shortcuts.

The other extension panorama tab groups uses message external and (in older versions) allowed toggling the panorama by external message.  See https://github.com/projectdelphai/panorama-tab-groups/pull/235