### PR TITLE
Add customizable active tab outline

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -47,6 +47,19 @@
 		"message": "List view for tiny tabs"
 	},
 
+	"optionTabAppearance": {
+		"message": "Tab Appearance"
+	},
+	"optionActiveTabOutlineWidth": {
+		"message": "Active tab outline width"
+	},
+	"optionActiveTabOutlineColor": {
+		"message": "Active tab outline color"
+	},
+	"optionResetColor": {
+		"message": "Reset"
+	},
+
 	"optionBackup": {
 		"message": "Backup"
 	},

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -47,6 +47,19 @@
 		"message": "小さなタブの一覧表示"
 	},
 
+	"optionTabAppearance": {
+		"message": "Tab Appearance"
+	},
+	"optionActiveTabOutlineWidth": {
+		"message": "Active tab outline width"
+	},
+	"optionActiveTabOutlineColor": {
+		"message": "Active tab outline color"
+	},
+	"optionResetColor": {
+		"message": "Reset"
+	},
+
 	"optionBackup": {
 		"message": "バックアップ"
 	},

--- a/src/common/theme.js
+++ b/src/common/theme.js
@@ -121,5 +121,8 @@ async function setAll(theme) {
 		let stylesheet = new CSSStyleSheet();
 		stylesheet.insertRule(style);
 		document.adoptedStyleSheets = [stylesheet];
+
+		// Dispatch event to notify other modules that theme has been applied
+		window.dispatchEvent(new CustomEvent('themeApplied'));
 	}
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -33,6 +33,21 @@
 			</div>
 		</section>
 		<section>
+			<h3 data-i18n-message-name="optionTabAppearance"></h3>
+			<div>
+				<div>
+					<label for="activeTabOutlineWidth" data-i18n-message-name="optionActiveTabOutlineWidth"></label>
+					<input type="range" id="activeTabOutlineWidth" min="1" max="5" step="1" value="2">
+					<output for="activeTabOutlineWidth" id="activeTabOutlineWidthValue"></output>
+				</div>
+				<div>
+					<label for="activeTabOutlineColor" data-i18n-message-name="optionActiveTabOutlineColor"></label>
+					<input type="color" id="activeTabOutlineColor" value="#45a1ff">
+					<button id="resetOutlineColor" data-i18n-message-name="optionResetColor"></button>
+				</div>
+			</div>
+		</section>
+		<section>
 			<h3 data-i18n-message-name="optionBackup"></h3>
 			<div>
 				<div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -134,6 +134,61 @@ document.addEventListener('DOMContentLoaded', async() => {
 	});
 	// ----
 
+	// active tab outline customization
+	const outlineWidthInput = document.getElementById('activeTabOutlineWidth');
+	const outlineWidthOutput = document.getElementById('activeTabOutlineWidthValue');
+	const outlineColorInput = document.getElementById('activeTabOutlineColor');
+	const resetColorButton = document.getElementById('resetOutlineColor');
+
+	// Load stored values or defaults
+	const outlineWidth = storage.hasOwnProperty('activeTabOutlineWidth') ? storage.activeTabOutlineWidth : 2;
+	const outlineColor = storage.hasOwnProperty('activeTabOutlineColor') ? storage.activeTabOutlineColor : '#45a1ff';
+
+	outlineWidthInput.value = outlineWidth;
+	outlineWidthOutput.textContent = outlineWidth + 'px';
+	outlineColorInput.value = outlineColor;
+
+	// Width change handler
+	outlineWidthInput.addEventListener('input', async(e) => {
+		const value = parseInt(e.target.value);
+		outlineWidthOutput.textContent = value + 'px';
+		await browser.storage.local.set({activeTabOutlineWidth: value});
+		browser.runtime.sendMessage({
+			event: 'addon.options.onUpdated',
+			data: {activeTabOutlineWidth: value}
+		});
+	});
+
+	// Color change handler
+	outlineColorInput.addEventListener('input', async(e) => {
+		await browser.storage.local.set({activeTabOutlineColor: e.target.value});
+		browser.runtime.sendMessage({
+			event: 'addon.options.onUpdated',
+			data: {activeTabOutlineColor: e.target.value}
+		});
+	});
+
+	// Reset color button
+	resetColorButton.addEventListener('click', async() => {
+		const defaultWidth = 2;
+		const defaultColor = '#45a1ff';
+		outlineWidthInput.value = defaultWidth;
+		outlineWidthOutput.textContent = defaultWidth + 'px';
+		outlineColorInput.value = defaultColor;
+		await browser.storage.local.set({
+			activeTabOutlineWidth: defaultWidth,
+			activeTabOutlineColor: defaultColor
+		});
+		browser.runtime.sendMessage({
+			event: 'addon.options.onUpdated',
+			data: {
+				activeTabOutlineWidth: defaultWidth,
+				activeTabOutlineColor: defaultColor
+			}
+		});
+	});
+	// ----
+
 	backup.createUI();
 
 	browser.tabs.onUpdated.addListener(getStatistics);


### PR DESCRIPTION
  - Add outline width setting (1-5px with slider)
  - Add outline color setting (with color picker)

These changes help people make more easy to them to find the active tab in cases of too many opened tabs (like me with 700+ tabes in 19 tab groups).
Default remains as it was.