### PR TITLE
Fix race condition hiding tabs moved between windows and mutex leak

### DIFF
--- a/src/background/addon.tabGroups.js
+++ b/src/background/addon.tabGroups.js
@@ -44,7 +44,10 @@ function sanitizeGroup(group) {
 
 export async function setActiveId(windowId, groupId) {
 	let unlock = await groupLock.lock();
-	if (!groups.find(group => group.id == groupId)) return undefined;
+	if (!groups.find(group => group.id == groupId)) {
+		await unlock();
+		return undefined;
+	}
 	await unlock();
 	return browser.sessions.setWindowValue(windowId, 'activeGroup', groupId);
 }

--- a/src/background/addon.tabs.events.js
+++ b/src/background/addon.tabs.events.js
@@ -80,6 +80,10 @@ async function attached(tabId, attachInfo) {
 			activeGroup = await addon.tabGroups.getActiveId(attachInfo.newWindowId);
 		}
 		await addon.tabs.setGroupId(tabId, activeGroup);
+
+		if (!(panoramaViewTab && panoramaViewTab.active)) {
+			browser.tabs.show(tabId);
+		}
 	}
 }
 
@@ -137,6 +141,7 @@ async function activated(activeInfo) {
 				while (tabGroupId == undefined) {
 					tabGroupId = await addon.tabGroups.getActiveId(activeInfo.windowId);
 				}
+				await addon.tabs.setGroupId(activeInfo.tabId, tabGroupId);
 			}
 			// ----
 


### PR DESCRIPTION
Fix race condition hiding tabs moved between windows and mutex leak

Firefox 148 landed sync about:blank ([Bug 543435](https://bugzilla.mozilla.org/show_bug.cgi?id=543435)), which changed tab adoption timing and introduced a race between the onAttached and onActivated event handlers. When a tab is dragged between windows, activated() could call toggleVisibleTabs before attached() finished updating the tab's groupId, causing the moved tab to be hidden.

Three issues fixed in addon.tabs.events.js:

1. activated() now persists the corrected groupId when it detects the active tab's group doesn't exist in the current window. Previously the fallback was only used locally for that one toggleVisibleTabs call, so the tab would be re-hidden on the next activation.

2. attached() now explicitly shows the tab after reassigning its group, recovering visibility if a racing toggleVisibleTabs already hid it.

Also fixed in addon.tabGroups.js:

3. setActiveId() returned early without releasing the mutex when the group was not found, which would deadlock all subsequent group operations (create, query, update, remove).

Refs: [Firefox Bug 543435](https://bugzilla.mozilla.org/show_bug.cgi?id=543435), [Bug 1987344](https://bugzilla.mozilla.org/show_bug.cgi?id=1987344), [Bug 2002643](https://bugzilla.mozilla.org/show_bug.cgi?id=2002643)
Refs: [#173](https://github.com/photodiode/panorama-view/issues/173)