### PR TITLE
Performance and security improvements

### DIFF
--- a/src/background/addon.js
+++ b/src/background/addon.js
@@ -22,7 +22,7 @@ export const addon = {
 function handleActions(message, sender, sendResponse) {
 
 	if (!message.action) return;
-	if (sender.id !== browser.runtime.id) return;
+	if (sender.id && sender.id !== browser.runtime.id) return;
 
 	let response;
 

--- a/src/background/addon.js
+++ b/src/background/addon.js
@@ -22,6 +22,7 @@ export const addon = {
 function handleActions(message, sender, sendResponse) {
 
 	if (!message.action) return;
+	if (sender.id !== browser.runtime.id) return;
 
 	let response;
 

--- a/src/background/addon.tabGroups.js
+++ b/src/background/addon.tabGroups.js
@@ -100,7 +100,7 @@ export async function create(info = {}, currentWindowId) {
 		title:          info.title || browser.i18n.getMessage('defaultGroupName'),
 		windowId:       info.windowId,
 
-		lastAccessed: (new Date).getTime(), // temporary
+		lastAccessed: Date.now(), // temporary
 	};
 
 	let unlock = await groupLock.lock();
@@ -182,7 +182,7 @@ export async function remove(groupId) {
 	// check if tabs were removed and abort if not (beforeunload was called or something)
 	for (const tabId of tabsToRemove) {
 		try {
-			tab = await browser.tabs.get(tabId);
+			const tab = await browser.tabs.get(tabId);
 			return undefined;
 		} catch (error) {
 			// all good, tab was removed
@@ -228,7 +228,7 @@ export async function update(groupId, info = {}) {
 		group.rect = info.rect;
 	}
 
-	group.lastAccessed = (new Date).getTime();
+	group.lastAccessed = Date.now();
 
 	await saveGroups();
 

--- a/src/background/addon.tabs.events.js
+++ b/src/background/addon.tabs.events.js
@@ -6,6 +6,10 @@ import * as core from './core.js';
 
 import * as backup from './backup.js';
 
+function sleep(ms) {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 
 export function initialize() {
 	browser.tabs.onCreated.addListener(created);
@@ -40,8 +44,9 @@ async function created(tab) {
 
 		if (!groupsExists) {
 			tab.groupId = undefined;
-			while (tab.groupId == undefined) {
+			for (let delay = 5; tab.groupId == undefined && delay <= 160; delay *= 2) {
 				tab.groupId = await addon.tabGroups.getActiveId(tab.windowId);
+				if (tab.groupId == undefined) await sleep(delay);
 			}
 		}
 	}
@@ -76,8 +81,9 @@ async function attached(tabId, attachInfo) {
 
 		let activeGroup = undefined;
 
-		while (activeGroup == undefined) {
+		for (let delay = 5; activeGroup == undefined && delay <= 160; delay *= 2) {
 			activeGroup = await addon.tabGroups.getActiveId(attachInfo.newWindowId);
+			if (activeGroup == undefined) await sleep(delay);
 		}
 		await addon.tabs.setGroupId(tabId, activeGroup);
 	}
@@ -105,12 +111,10 @@ async function updated(tabId, changeInfo, tab) {
 	}
 
 	if (tab.groupId == undefined) {
-		const start = (new Date).getTime();
-		while (tab.groupId == undefined) {
+		for (let delay = 5; tab.groupId == undefined && delay <= 80; delay *= 2) {
 			tab.groupId = await addon.tabs.getGroupId(tab.id);
-			if (((new Date).getTime() - start) > 50) break; // timeout
+			if (tab.groupId == undefined) await sleep(delay);
 		}
-
 	}
 
 	const sending = browser.runtime.sendMessage({event: 'browser.tabs.onUpdated', tabId: tabId, changeInfo: changeInfo, tab: tab});
@@ -134,14 +138,19 @@ async function activated(activeInfo) {
 
 			if (!groupsExists) {
 				tabGroupId = undefined;
-				while (tabGroupId == undefined) {
+				for (let delay = 5; tabGroupId == undefined && delay <= 160; delay *= 2) {
 					tabGroupId = await addon.tabGroups.getActiveId(activeInfo.windowId);
+					if (tabGroupId == undefined) await sleep(delay);
 				}
 			}
 			// ----
 
-			addon.tabGroups.setActiveId(tab.windowId, tabGroupId);
+			if (tabGroupId != undefined) {
+				addon.tabGroups.setActiveId(tab.windowId, tabGroupId);
+			}
 		}
-		core.toggleVisibleTabs(tab.windowId, tabGroupId);
+		if (tabGroupId != undefined) {
+			core.toggleVisibleTabs(tab.windowId, tabGroupId);
+		}
 	}
 }

--- a/src/background/addon.tabs.js
+++ b/src/background/addon.tabs.js
@@ -1,6 +1,10 @@
 
 'use strict';
 
+function sleep(ms) {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 export function setGroupId(tabId, groupId) {
 	return browser.sessions.setTabValue(tabId, 'groupId', groupId);
 }
@@ -11,9 +15,15 @@ export function getGroupId(tabId) {
 
 export async function getGroupIdTimeout(tabId, timeout) {
 	let groupId = undefined;
-	const start = (new Date).getTime();
-	while (groupId == undefined && (((new Date).getTime() - start) < timeout)) {
+	let elapsed = 0;
+	let delay = 5;
+	while (groupId == undefined && elapsed < timeout) {
 		groupId = await browser.sessions.getTabValue(tabId, 'groupId');
+		if (groupId == undefined) {
+			await sleep(delay);
+			elapsed += delay;
+			delay = Math.min(delay * 2, 50);
+		}
 	}
 	return groupId;
 }

--- a/src/background/backup.js
+++ b/src/background/backup.js
@@ -174,7 +174,7 @@ async function autoBackup() {
 	}
 
 	let backup = {
-		time: (new Date).getTime(),
+		time: Date.now(),
 		data: await create()
 	}
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -73,13 +73,14 @@
 		"browser_style": true
 	},
 
+	"content_security_policy": "script-src 'self'; object-src 'self'",
+
 	"permissions": [
 		"<all_urls>",
 		"tabs",
 		"tabHide",
 		"storage",
 		"sessions",
-		"cookies",
 		"contextualIdentities",
 		"downloads",
 		"menus"

--- a/src/options/options.backup.js
+++ b/src/options/options.backup.js
@@ -69,7 +69,13 @@ async function loadBackup() {
 		const reader = new FileReader();
 
 		reader.onload = (json) => {
-			let backup = JSON.parse(json.target.result);
+			let backup;
+			try {
+				backup = JSON.parse(json.target.result);
+			} catch (e) {
+				alert(browser.i18n.getMessage('optionLoadError'));
+				return;
+			}
 
 			if ((backup.version && backup.version[0] == 'tabGroups' || backup.version && backup.version[0] == 'sessionrestore') && backup.version[1] == 1) {
 				// convert from old tab groups backup to version 1 (legacy)

--- a/src/panorama/js/html.tabs.js
+++ b/src/panorama/js/html.tabs.js
@@ -19,6 +19,12 @@ export function create(tab) {
 
 	const node = newElement('div', {href: '', class: 'tab', draggable: 'true', 'data-id': tab.id, title: '', tabindex: 0}, [container, context]);
 
+	if (browser.tabs.warmup) {
+		node.addEventListener('mouseenter', () => {
+			browser.tabs.warmup(tab.id).catch(() => {});
+		}, false);
+	}
+
 	node.addEventListener('click', (event) => {
 		event.preventDefault();
 		if (event.ctrlKey) {
@@ -90,7 +96,9 @@ export async function update(tabNode, tab) {
 			tabNode.querySelector('.context').title = contextInfo.name;
 		}
 
-		tabNode.title = tab.title + ((tab.url.substr(0, 5) != 'data:') ? ' - ' + decodeURI(tab.url) : '');
+		let displayUrl = tab.url;
+		try { displayUrl = decodeURI(tab.url); } catch (e) { /* malformed URI */ }
+		tabNode.title = tab.title + ((tab.url.substr(0, 5) != 'data:') ? ' - ' + displayUrl : '');
 
 		if (tab.discarded) {
 			tabNode.classList.add('inactive');

--- a/src/panorama/js/view.js
+++ b/src/panorama/js/view.js
@@ -58,7 +58,7 @@ document.addEventListener('DOMContentLoaded', async() => {
 	document.addEventListener('visibilitychange', async() => {
 		if (document.hidden) {
 			browser.tabs.onUpdated.removeListener(captureThumbnail);
-			viewLastAccessed = (new Date).getTime();
+			viewLastAccessed = Date.now();
 		} else {
 			await captureThumbnails();
 			browser.tabs.onUpdated.addListener(captureThumbnail, {properties: ['url', 'status']});
@@ -127,7 +127,7 @@ document.addEventListener('DOMContentLoaded', async() => {
 	// tab events
 	browser.tabs.onCreated.addListener(events.tabCreated);
 	browser.tabs.onRemoved.addListener(events.tabRemoved);
-	browser.tabs.onUpdated.addListener(events.tabUpdated), {properties: ['favIconUrl', 'pinned', 'title', 'url', 'discarded', 'status']};
+	browser.tabs.onUpdated.addListener(events.tabUpdated, {properties: ['favIconUrl', 'pinned', 'title', 'url', 'discarded', 'status']});
 
 	browser.tabs.onActivated.addListener(events.tabActivated);
 


### PR DESCRIPTION
## Summary

**Performance**
- Fix `onUpdated` event filter not being applied — the property filter
  object was outside the `addListener()` parentheses (comma expression),
  so every tab update fired the handler instead of only the six listed
  properties
- Replace busy-wait polling with exponential backoff — all `while` loops
  that spun on `getTabValue`/`getActiveId` with no delay now use bounded
  retries (5ms→10ms→20ms…) with timeouts, eliminating CPU spinning and
  potential infinite hangs
- Add `tabs.warmup()` on tab hover — pre-renders GPU resources when the
  user hovers a thumbnail, making subsequent tab switches faster
- Replace `(new Date).getTime()` with `Date.now()` across the codebase

**Security**
- Add explicit `content_security_policy` to manifest.json (matches
  Firefox default but makes the policy explicit)
- Remove unused `cookies` permission — reduces attack surface
- Fix undeclared `tab` variable in `remove()` — missing `const` caused a
  strict-mode ReferenceError that silently broke the "were tabs actually
  closed?" verification
- Validate message sender — background message handler now rejects
  messages from external extensions via `sender.id` check
- Add error handling for `JSON.parse` (backup restore) and `decodeURI`
  (tab tooltips) to prevent crashes on malformed input

## Test plan

- [ ] Open Panorama View and verify tab groups display correctly
- [ ] Create, rename, and remove tab groups
- [ ] Hover over tab thumbnails, then click to switch — confirm switching
      feels responsive
- [ ] Drag tabs between groups
- [ ] Move tabs between windows and confirm they appear in the correct group
- [ ] Use keyboard shortcuts to cycle through groups (Ctrl+Alt+W / Q)
- [ ] Save and restore a backup file
- [ ] Attempt to load a non-JSON file as backup — should show error, not crash
- [ ] Verify on both Firefox < 138 (polyfill path) and Firefox ≥ 138 (native
      tabGroups API) if possible