### PR TITLE
Fix backup creation crashing on missing session data

### DIFF
--- a/src/background/backup.js
+++ b/src/background/backup.js
@@ -27,6 +27,8 @@ export async function create(appId) {
 	for (const window of windows) {
 
 		const groups = await browser.sessions.getWindowValue(window.id, 'groups');
+		if (!groups) continue;
+
 		groups.sort((a, b) => {
 			return a.lastAccessed - b.lastAccessed;
 		});
@@ -45,6 +47,7 @@ export async function create(appId) {
 		for (const group of groups) {
 
 			let rect = await addon.tabGroups.getGroupValue(group.id, 'rect', browser.runtime.id);
+			if (!rect) rect = {x: 0, y: 0, w: 0.5, h: 0.5};
 
 			let tabGroup = {
 				title: group.title,


### PR DESCRIPTION
## Summary

- `backup.create()` crashes when a window has no groups stored in session data, or when a group has no stored `rect` value — both result in a TypeError on a null/undefined reference
- This broke both manual "Save As" and automatic backups, likely since Firefox 148 changed session storage behavior around January 2026
- Skip windows with missing group data instead of crashing
- Fall back to default rect `{x:0, y:0, w:0.5, h:0.5}` (same default used in `view.js`) when a group has no stored position

## Test plan

- [ ] Open options page and click "Save As" — should prompt a file save
- [ ] Verify the saved JSON contains correct group/tab data
- [ ] Trigger an automatic backup (set interval, wait, check dropdown)
- [ ] Restore a backup and verify groups/tabs are recreated