### PR TITLE
Add configurable max auto-backup count (default 3, max 20)

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -83,6 +83,9 @@
 	"optionAutomaticBackupIntervalValue": {
 		"message": "$1h $2min"
 	},
+	"optionMaxBackups": {
+		"message": "Maximum number of auto backups"
+	},
 
 	"optionStatistics": {
 		"message": "Statistics"

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -83,6 +83,9 @@
 	"optionAutomaticBackupIntervalValue": {
 		"message": "$1時間$2分"
 	},
+	"optionMaxBackups": {
+		"message": "自動バックアップの最大数"
+	},
 
 	"optionStatistics": {
 		"message": "情報"

--- a/src/background/addon.js
+++ b/src/background/addon.js
@@ -106,6 +106,14 @@ function handleActions(message, sender, sendResponse) {
 			response = backup.getBackups();
 			break;
 		}
+		case 'addon.backup.getMaxBackups': {
+			response = backup.getMaxBackups();
+			break;
+		}
+		case 'addon.backup.setMaxBackups': {
+			response = backup.setMaxBackups(message.count);
+			break;
+		}
 		// ----
 
 		default:

--- a/src/background/backup.js
+++ b/src/background/backup.js
@@ -27,6 +27,8 @@ export async function create(appId) {
 	for (const window of windows) {
 
 		const groups = await browser.sessions.getWindowValue(window.id, 'groups');
+		if (!groups) continue;
+
 		groups.sort((a, b) => {
 			return a.lastAccessed - b.lastAccessed;
 		});
@@ -45,6 +47,7 @@ export async function create(appId) {
 		for (const group of groups) {
 
 			let rect = await addon.tabGroups.getGroupValue(group.id, 'rect', browser.runtime.id);
+			if (!rect) rect = {x: 0, y: 0, w: 0.5, h: 0.5};
 
 			let tabGroup = {
 				title: group.title,

--- a/src/background/backup.js
+++ b/src/background/backup.js
@@ -168,6 +168,21 @@ export async function getBackups() {
 	return (await browser.storage.local.get('autoBackup')).autoBackup || [];
 }
 
+export async function setMaxBackups(count) {
+	count = Math.max(1, Math.min(20, parseInt(count, 10) || 3));
+	await browser.storage.local.set({autoBackupMaxCount: count});
+
+	let storage = await browser.storage.local.get('autoBackup');
+	if (storage.autoBackup && storage.autoBackup.length > count) {
+		storage.autoBackup.length = count;
+		await browser.storage.local.set(storage);
+	}
+}
+
+export async function getMaxBackups() {
+	return (await browser.storage.local.get('autoBackupMaxCount')).autoBackupMaxCount || 3;
+}
+
 async function autoBackup() {
 
 	let storage = await browser.storage.local.get('autoBackup');
@@ -183,7 +198,8 @@ async function autoBackup() {
 
 	storage.autoBackup.unshift(backup);
 
-	if (storage.autoBackup.length > 3) {
+	const maxBackups = await getMaxBackups();
+	while (storage.autoBackup.length > maxBackups) {
 		storage.autoBackup.pop();
 	}
 

--- a/src/options/options.backup.js
+++ b/src/options/options.backup.js
@@ -93,7 +93,7 @@ async function loadBackup() {
 
 		const i = Number(selectBackup.value);
 
-		if (i < 0 || i > 3) {
+		if (i < 0 || i >= autoBackups.length) {
 			return;
 		}
 
@@ -277,6 +277,28 @@ export async function createUI() {
 			action: 'addon.backup.setInterval',
 			interval: autoBackup.value
 		});
+	});
+	// ----
+
+	// Max Backups
+	const maxBackupsInput = document.getElementById('maxBackups');
+
+	maxBackupsInput.value = await browser.runtime.sendMessage({
+		action: 'addon.backup.getMaxBackups'
+	});
+
+	maxBackupsInput.addEventListener('change', async function() {
+		let value = Math.max(1, Math.min(20, parseInt(this.value, 10) || 3));
+		this.value = value;
+		await browser.runtime.sendMessage({
+			action: 'addon.backup.setMaxBackups',
+			count: value
+		});
+
+		autoBackups = await browser.runtime.sendMessage({
+			action: 'addon.backup.getBackups'
+		});
+		fillBackupSelection(autoBackups);
 	});
 	// ----
 }

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -31,3 +31,8 @@ input[type="range"] {
 	margin-right: 1ch;
 	vertical-align: middle;
 }
+
+input[type="number"] {
+	width: 4em;
+	vertical-align: middle;
+}

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -53,6 +53,10 @@
 					<input type="range" id="autoBackup" min="0" max="360" step="15" value="0">
 					<output for="autoBackup" id="autoBackupInterval"></output>
 				</div>
+				<div>
+					<label data-i18n-message-name="optionMaxBackups"></label>
+					<input type="number" id="maxBackups" min="1" max="20" value="3">
+				</div>
 			</div>
 		</section>
 		<section>


### PR DESCRIPTION
Replace the hardcoded 3-backup limit with a user-configurable setting.
Adds a number input to the options page, stores the value in extension storage, and trims existing backups immediately when the count is reduced. Also fixes an off-by-one guard in backup loading (i > 3 → i >= autoBackups.length).

Closes #170